### PR TITLE
Z-Mimic Fixes Pack 3

### DIFF
--- a/code/__DEFINES/rendering/ao.dm
+++ b/code/__DEFINES/rendering/ao.dm
@@ -3,6 +3,7 @@
  */
 
 #define WALL_AO_ALPHA 80
+#define Z_AO_ALPHA 160
 
 #define AO_UPDATE_NONE    0
 #define AO_UPDATE_OVERLAY 1

--- a/code/__DEFINES/rendering/lighting.dm
+++ b/code/__DEFINES/rendering/lighting.dm
@@ -31,6 +31,9 @@
  */
 #define USE_INTELLIGENT_LIGHTING_UPDATES
 
+/// Maximum light_range before forced to always queue instead of using sync updates. Setting this too high will cause server stutter with moving large lights.
+#define LIGHTING_MAXIMUM_INSTANT_RANGE 8
+
 /**
  * Mostly identical to below, but doesn't make sure T is valid first.
  * Should only be used by lighting code.

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -114,7 +114,7 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/proc/InitializeZlev(zlev)
 	for (var/thing in Z_ALL_TURFS(zlev))
 		var/turf/T = thing
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))	// Can't assume that one hasn't already been created on bay/neb.
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
 			if (T.lighting_overlay)
 				log_subsystem(name, "Found unexpected lighting overlay at [T.x],[T.y],[T.z]")
 			else

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -93,9 +93,12 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/proc/InitializeZlev(zlev)
 	for (var/thing in Z_ALL_TURFS(zlev))
 		var/turf/T = thing
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T) && !T.lighting_overlay)	// Can't assume that one hasn't already been created on bay/neb.
-			new /atom/movable/lighting_overlay(T)
-			. += 1
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))	// Can't assume that one hasn't already been created on bay/neb.
+			if (T.lighting_overlay)
+				log_subsystem(name, "Found unexpected lighting overlay at [T.x],[T.y],[T.z]")
+			else
+				new /atom/movable/lighting_overlay(T)
+				. += 1
 			if (T.ambient_light)
 				T.generate_missing_corners()	// Forcibly generate corners.
 

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -59,7 +59,12 @@ SUBSYSTEM_DEF(nightshift)
 			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
 		else
 			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
+
+	SSlighting.pause_instant()
+
 	for(var/obj/machinery/power/apc/apc in GLOB.apcs)
 		if(apc.z in GLOB.using_map.station_levels)
 			apc.set_nightshift(active, TRUE)
 			CHECK_TICK
+
+	SSlighting.resume_instant()

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -1,18 +1,24 @@
+#ifdef AO_USE_LIGHTING_OPACITY
+#define AO_TURF_CHECK(T) (!T.has_opaque_atom || !T.permit_ao)
+#define AO_SELF_CHECK(T) (!T.has_opaque_atom)
+#else
 #define AO_TURF_CHECK(T) (!T.density || !T.opacity || !T.permit_ao)
 #define AO_SELF_CHECK(T) (!T.density && !T.opacity)
+#endif
 
-/turf/var/permit_ao = TRUE
-/// Current ambient occlusion overlays. Tracked so we can reverse them without dropping all priority overlays.
-/turf/var/tmp/list/ao_overlays
-/turf/var/tmp/ao_neighbors
-/turf/var/tmp/list/ao_overlays_mimic
-/turf/var/tmp/ao_neighbors_mimic
-/turf/var/ao_queued = AO_UPDATE_NONE
+/turf
+	var/permit_ao = TRUE
+	/// Current ambient occlusion overlays. Tracked so we can reverse them without dropping all priority overlays.
+	var/tmp/list/ao_overlays
+	var/tmp/ao_neighbors
+	var/tmp/list/ao_overlays_mimic
+	var/tmp/ao_neighbors_mimic
+	var/ao_queued = AO_UPDATE_NONE
 
 /turf/proc/regenerate_ao()
-	for(var/thing in RANGE_TURFS(1, src))
+	for (var/thing in RANGE_TURFS(1, src))
 		var/turf/T = thing
-		if(istype(T) && T.permit_ao)
+		if (T?.permit_ao)
 			T.queue_ao(TRUE)
 
 /turf/proc/calculate_ao_neighbors()
@@ -28,13 +34,14 @@
 		CALCULATE_NEIGHBORS(src, ao_neighbors, T, AO_TURF_CHECK(T))
 
 // TODO: Prebaked AO? @Zandario
-/proc/make_ao_image(corner, i, px = 0, py = 0, pz = 0, pw = 0)
+/proc/make_ao_image(corner, i, px = 0, py = 0, pz = 0, pw = 0, alpha)
 	var/list/cache = SSao.image_cache
 	var/cstr = "[corner]"
-	var/key = "[cstr]-[i]-[px]/[py]/[pz]/[pw]"
+	// PROCESS_AO_CORNER below also uses this cache, check it before changing this key.
+	var/key = "[cstr]|[i]|[px]/[py]/[pz]/[pw]|[alpha]"
 
 	var/image/I = image('icons/turf/flooring/shadows.dmi', cstr, dir = 1 << (i-1))
-	I.alpha = WALL_AO_ALPHA
+	I.alpha = alpha
 	I.blend_mode = BLEND_OVERLAY
 	I.appearance_flags = RESET_ALPHA|RESET_COLOR|TILE_BOUND
 	I.layer = AO_LAYER
@@ -55,7 +62,7 @@
 	if (ao_queued < new_level)
 		ao_queued = new_level
 
-#define PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, CORNER_INDEX, CDIR) \
+#define PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, CORNER_INDEX, CDIR, ALPHA, TARGET) \
 	corner = 0; \
 	if (NEIGHBORS & (1 << CDIR)) { \
 		corner |= 2; \
@@ -67,9 +74,9 @@
 		corner |= 4; \
 	} \
 	if (corner != 7) {	/* 7 is the 'no shadows' state, no reason to add overlays for it. */ \
-		var/image/I = cache["[corner]-[CORNER_INDEX]-[pixel_x]/[pixel_y]/[pixel_z]/[pixel_w]"]; \
+		var/image/I = cache["[corner]|[CORNER_INDEX]|[pixel_x]/[pixel_y]/[pixel_z]/[pixel_w]|[ALPHA]"]; \
 		if (!I) { \
-			I = make_ao_image(corner, CORNER_INDEX, pixel_x, pixel_y, pixel_z, pixel_w)	/* this will also add the image to the cache. */ \
+			I = make_ao_image(corner, CORNER_INDEX, TARGET.pixel_x, TARGET.pixel_y, TARGET.pixel_z, TARGET.pixel_w, ALPHA)	/* this will also add the image to the cache. */ \
 		} \
 		LAZYADD(AO_LIST, I); \
 	}
@@ -80,13 +87,13 @@
 		AO_LIST.Cut(); \
 	}
 
-#define REGEN_AO(TARGET, AO_LIST, NEIGHBORS) \
+#define REGEN_AO(TARGET, AO_LIST, NEIGHBORS, ALPHA) \
 	if (permit_ao && NEIGHBORS != AO_ALL_NEIGHBORS) { \
 		var/corner;\
-		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 1, NORTHWEST); \
-		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 2, SOUTHEAST); \
-		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 3, NORTHEAST); \
-		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 4, SOUTHWEST); \
+		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 1, NORTHWEST, ALPHA, TARGET); \
+		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 2, SOUTHEAST, ALPHA, TARGET); \
+		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 3, NORTHEAST, ALPHA, TARGET); \
+		PROCESS_AO_CORNER(AO_LIST, NEIGHBORS, 4, SOUTHWEST, ALPHA, TARGET); \
 	} \
 	UNSETEMPTY(AO_LIST); \
 	if (AO_LIST) { \
@@ -98,11 +105,9 @@
 	CUT_AO(shadower, ao_overlays_mimic)
 	CUT_AO(src, ao_overlays)
 	if (mz_flags & MZ_MIMIC_BELOW)
-		REGEN_AO(shadower, ao_overlays_mimic, ao_neighbors_mimic)
+		REGEN_AO(shadower, ao_overlays_mimic, ao_neighbors_mimic, Z_AO_ALPHA)
 	if (AO_TURF_CHECK(src) && !(mz_flags & MZ_MIMIC_NO_AO))
-		REGEN_AO(src, ao_overlays, ao_neighbors)
-
-	update_above()
+		REGEN_AO(src, ao_overlays, ao_neighbors, WALL_AO_ALPHA)
 
 #undef REGEN_AO
 #undef PROCESS_AO_CORNER

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -113,7 +113,7 @@
 		needs_update = level;                          \
 	}                                                  \
 	if (_should_update) {                              \
-		if (world.tick_usage > Master.current_ticklimit || SSlighting.force_queued) {	\
+		if (world.tick_usage > (Master.current_ticklimit/2) || light_range > LIGHTING_MAXIMUM_INSTANT_RANGE || SSlighting.force_queued) {	\
 			SSlighting.light_queue += src;              \
 		}                                               \
 		else {                                          \

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -110,8 +110,7 @@
 // Builds a lighting overlay for us, but only if our area is dynamic.
 /turf/proc/lighting_build_overlay(now = FALSE)
 	if (lighting_overlay)
-		return	// shrug
-		// CRASH("Attempted to create lighting_overlay on tile that already had one.")
+		CRASH("Attempted to create lighting_overlay on tile that already had one.")
 
 	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
 		if (!lighting_corners_initialised || !corners)


### PR DESCRIPTION
- Z-AO now has an independent alpha value, currently set to 2x the wall AO value.
- AO should behave better on pixel-shifted turfs.
- Reenables some sanity checks on lighting overlay existence that appear to work here.
- Attempts to address lag from large light sources and nightshift hitting the instant update path.